### PR TITLE
Fixed crashing issue caused by hide button

### DIFF
--- a/src/component/Controls.js
+++ b/src/component/Controls.js
@@ -22,7 +22,9 @@ class Controls extends React.Component {
     }
 
     componentDidUpdate = () => {
-        if (this.needsUrlChange) this.urlInput.current.value = this.props.video_url;
+        if (this.needsUrlChange && (this.urlInput && this.urlInput.current)) {
+            this.urlInput.current.value = this.props.video_url;
+        }
     }
 
     setUsername = () => {


### PR DESCRIPTION
Hi Jackson,

Gabe and I found a small issue, the app was crashing when a new video url was loaded while the hide button was active. This occurred because the urlInput.current was not initialized when the controls were hidden. I have just added a check to make sure it doesn't crash. 